### PR TITLE
update express url resolution path

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ app.use(express.static(__dirname + "/dist"));
 
 // send the user to index html page inspite of the url
 app.get("*", (req, res) => {
-  res.sendFile(path.resolve(__dirname, "index.html"));
+  res.sendFile(path.resolve(__dirname, "./dist/index.html"));
 });
 
 app.listen(port);


### PR DESCRIPTION
Previous path renders error with any non-default (homepage) URL request:

"ENOENT: no such file or directory, stat 'index.html' at Error "

Updated resolution provides a clear reference path to the index page ('./dist/index.html').

